### PR TITLE
Create Version `*`

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
     "minecraft": "1.18.x",
     "java": ">=17",
     "roughlyenoughitems": "*",
-    "create": ">=0.5.1"
+    "create": "*"
   }
 }


### PR DESCRIPTION
In case for vicious version components. `>=0.5.1` doesn't work.